### PR TITLE
we need a customized default vhost, since puppet will not configure a working

### DIFF
--- a/default/puppet/manifests/site.pp
+++ b/default/puppet/manifests/site.pp
@@ -2,7 +2,27 @@
 
 
 class { 'apache':
-  default_mods => false,
+  default_mods  => false,
+  default_vhost => false,
+}
+
+::apache::vhost { 'hardening-default':
+  port            => 80,
+  docroot         => $::apache::docroot,
+  scriptalias     => $::apache::scriptalias,
+  serveradmin     => $::apache::serveradmin,
+  access_log_file => $::apache::access_log_file,
+  priority        => '25',
+  directories     => [
+    { 'path'           => $::apache::docroot,
+      'provider'       => 'files',
+      'allow'          => 'from all',
+      'order'          => 'allow,deny',
+      'options'        => ['-Indexes','-FollowSymLinks','+MultiViews'],
+      'allow_override' => ['None'],
+
+    },
+  ]
 }
 
 class { 'apache_hardening':


### PR DESCRIPTION
apache config otherwise (missing ports)

TelekomLabs-DCO-1.1-Signed-off-by: Edmund Haselwanter <me@ehaselwanter.com>
(github: ehaselwanter)